### PR TITLE
oc-CHRON-4048 -- fix web3 transactions

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -72,10 +72,6 @@ function Provider(rpcUrl, userType, secret, contracts, params, finalCallback) {
   var web3 = new Web3(engine);
   var addr;
 
-  engine.addProvider(new RpcSubprovider({
-    rpcUrl: rpcUrl || 'http://localhost:8545'
-  }));
-
   engine.addProvider(new FixtureSubprovider({
     web3_clientVersion: 'ProviderEngine/v0.0.0/javascript',
     net_listening: true,
@@ -175,6 +171,10 @@ function Provider(rpcUrl, userType, secret, contracts, params, finalCallback) {
   //     instantiateSdk();
   //   }
   // });
+
+  engine.addProvider(new RpcSubprovider({
+    rpcUrl: rpcUrl || 'http://localhost:8545'
+  }));
 
   engine.start();
 


### PR DESCRIPTION
A previous update that I performed had rearranged the sub-provider injection (which function like middleware when sending ethereum transaction) in such a way that transactions were NOT being signed BEFORE being sent to the Quorum/Ethereum RPC Node. This update fixes that by injecting the RPC Subprovider last, so the signing middleware provided by the HookedWallet Subprovider correctly signs the data in the transaction before sending it to the RPC.