### PR TITLE
4054 - Web3 Provider Request error

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -308,7 +308,7 @@ Consumer.prototype.getRegistrantsEvents = function(fromBlock, toBlock) {
       return event;
     });
   }).finally(function() {
-    filter.stopWatching();
+    return Promise.promisify(filter.stopWatching.bind(filter))();
   });
 };
 

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -235,7 +235,7 @@ Consumer.prototype.getThingsEvents = function(fromBlock, toBlock) {
       return event;
     });
   }).finally(function() {
-    filter.stopWatching();
+    return Promise.promisify(filter.stopWatching.bind(filter))();
   });
 };
 


### PR DESCRIPTION
The Web3 Provider Engine does not allow synchronous requests, yet the stopWatching request was synchronous because no callback was being handed to the function. To fix this, I have promisified the function so it is now asynchronous.