### PR TITLE
update gas settings + event retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ server_modules
 
 environments
 
+.DS_Store
 node_modules
 playground
 build

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -226,10 +226,7 @@ Consumer.prototype.getThingsEvents = function(fromBlock, toBlock) {
   toBlock = toBlock || 'latest';
   var filter = Promise.promisifyAll(this.registry.allEvents({fromBlock: fromBlock, toBlock: toBlock}));
   return filter.getAsync().then(function(events) {
-    var filteredEvents = events.filter(function(event) {
-      return event.event !== 'Error';
-    });
-    var sortedEvents = sortEvents(filteredEvents);
+    var sortedEvents = sortEvents(events);
     return sortedEvents.map(function(event) {
       event.args.identities = OrUtils.common.compressAll(OrUtils.urn.packer.decode(event.args.ids));
       return event;

--- a/lib/registrant.js
+++ b/lib/registrant.js
@@ -158,9 +158,11 @@ Registrant.prototype.updateThingData = function(identity, data, schemaIndex, opt
  * @returns {Promise} that resolves with transaction hash of the operation.
  * @note Sends transaction, costs Ether.
  */
-Registrant.prototype.deleteThing = function(identity) {
+Registrant.prototype.deleteThing = function(identity, opts = {}) {
+  const defaults = { gas: 4000000};
+  const settings = Object.assign({}, defaults, opts);
   var encodedIdentity = OrUtils.urn.packer.encodeAndChunk(OrUtils.common.compressAll(identity));
-  return this.registry.deleteThingAsync(encodedIdentity, {from: this.address});
+  return this.registry.deleteThingAsync(encodedIdentity, {from: this.address, gas: settings.gas});
 };
 /**
  * Add identities to the existing Thing on the blockchain.

--- a/lib/registrant.js
+++ b/lib/registrant.js
@@ -159,7 +159,7 @@ Registrant.prototype.updateThingData = function(identity, data, schemaIndex, opt
  * @note Sends transaction, costs Ether.
  */
 Registrant.prototype.deleteThing = function(identity, opts = {}) {
-  const defaults = { gas: 4000000};
+  const defaults = { gas: 400000};
   const settings = Object.assign({}, defaults, opts);
   var encodedIdentity = OrUtils.urn.packer.encodeAndChunk(OrUtils.common.compressAll(identity));
   return this.registry.deleteThingAsync(encodedIdentity, {from: this.address, gas: settings.gas});


### PR DESCRIPTION
1. Updates the Delete Thing's Transaction submission to also specify the gas (fixing the out-of-gas error seen earlier)
2. Removes the `Error` event filter when fetching events so that at the SDK level, we can see error events (the server only parses 'Created' and 'Updated' Events for now though.